### PR TITLE
Use a nix-shell based interpreter

### DIFF
--- a/niceshare.py
+++ b/niceshare.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/env nix-shell
+#! nix-shell -i python3 -p python3 -p python3Packages.wxPython_4_0
 
 import argparse
 import itertools


### PR DESCRIPTION
This way we don't need to install any python packages globally.